### PR TITLE
Implement timeout on sync read for protocol v1

### DIFF
--- a/src/protocol/v1.rs
+++ b/src/protocol/v1.rs
@@ -260,6 +260,15 @@ impl Protocol<PacketV1> for V1 {
                 .map(|slice| slice.to_vec())
                 .collect();
 
+            // In protocol v1, timeout are detected because all expected values are replaced by 255
+            let timeout: Vec<_> = result
+                .iter()
+                .filter(|r| r.iter().all(|&el| el == u8::MAX))
+                .collect();
+            if !timeout.is_empty() {
+                return Err(Box::new(CommunicationErrorKind::TimeoutError));
+            }
+
             Ok(result)
         }
     }


### PR DESCRIPTION
Fix #9 

If a slice of 255 value is found in the response, the whole message is thrown away and a TimeoutError is raised instead.

We could keep the other values and only throw away the ones that actually did timeout. Yet, none of the above API was designed for this specific case. We have the same behavior for protocol v2. I've created #19 to track the issue.