### PR TITLE
Parallel read and write

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ categories = ["science::robotics"]
 log = "0.4.17"
 paste = "1.0.10"
 serialport = "4.2.0"
+rayon = "1.10"
 clap = { version = "4.0.32", features = ["derive"] }
 
 [dev-dependencies]

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,6 +1,8 @@
 //! High-level register access functions for a specific dynamixel device
 
 use paste::paste;
+use rayon::iter::IntoParallelRefIterator;
+use rayon::iter::ParallelIterator;
 use std::mem::size_of;
 
 use crate::{reg_read_only, reg_read_write, DynamixelSerialIO, Result};
@@ -31,7 +33,7 @@ macro_rules! reg_read_only {
         ) -> Result<Vec<$reg_type>> {
             let val = io.sync_read(serial_port, ids, $addr, size_of::<$reg_type>().try_into().unwrap())?;
             let val = val
-                .iter()
+                .par_iter()
                 .map(|v| $reg_type::from_le_bytes(v.as_slice().try_into().unwrap()))
                 .collect();
 
@@ -69,7 +71,7 @@ macro_rules! reg_write_only {
                     ids,
                     $addr,
                     &values
-                        .iter()
+                        .par_iter()
                         .map(|v| v.to_le_bytes().to_vec())
                         .collect::<Vec<Vec<u8>>>(),
                 )


### PR DESCRIPTION
Adding parallel read write when using `reg_read_only` `reg_write_only`.

Previous implementation used to read sequentially each motor instead of reading and writing them concurrently.

This use rayon threadpool to make it performant.

Future PR could use tokio threadpool instead and async so that we can read and write concurrently.

On my arm, I'm able to divide by 2 read and write time.