### PR TITLE
Fix call to check_response_size! in sync_read_*

### DIFF
--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -80,7 +80,7 @@ macro_rules! reg_read_only {
             ids: &[u8],
         ) -> Result<Vec<$reg_type>> {
             let val = io.sync_read(serial_port, ids, $addr, size_of::<$reg_type>().try_into().unwrap())?;
-            check_response_size!(&val, $reg_type);
+            check_response_size!(&val[0], $reg_type);
             let val = val
                 .iter()
                 .map(|v| $reg_type::from_le_bytes(v.as_slice().try_into().unwrap()))


### PR DESCRIPTION
Previously it was checking that the length of the returned array (which is a Vec<Vec<u8>>) was == size_of(reg_type).

Hilariously this worked for one of my reads, where I was reading 8 values of type u8, but then it blew up for when I was reading 8 values of type i32.

It's not totally clear to me what value these asserts provide. You'd expect a check inside read and indeed it appear sthere is one:

```
if status_packet.params().len() != (length as usize * ids.len()) {
            Err(Box::new(CommunicationErrorKind::ParsingError))
        }
```

But for now, I'm changing the check to ensure they byte length of the value matches the byte length of the type.