### PR TITLE
Fix default clippy lints.

### DIFF
--- a/src/dynamixel_protocol/mod.rs
+++ b/src/dynamixel_protocol/mod.rs
@@ -417,7 +417,7 @@ trait Protocol<P: Packet> {
         data.extend(header);
         data.extend(payload);
 
-        log::debug!("<<< {:?}", data);
+        log::debug!("<<< {data:?}");
 
         P::status_packet(&data, sender_id)
     }
@@ -430,7 +430,7 @@ trait Protocol<P: Packet> {
     fn flush(&self, port: &mut dyn SerialPort) -> Result<()> {
         let n = port.bytes_to_read()? as usize;
         if n > 0 {
-            log::info!("Needed to flush serial port ({} bytes)...", n);
+            log::info!("Needed to flush serial port ({n} bytes)...");
             let mut buff = vec![0u8; n];
             port.read_exact(&mut buff)?;
         }
@@ -463,7 +463,7 @@ impl fmt::Display for CommunicationErrorKind {
             CommunicationErrorKind::ParsingError => write!(f, "Parsing error"),
             CommunicationErrorKind::TimeoutError => write!(f, "Timeout error"),
             CommunicationErrorKind::IncorrectId(sender_id, resp_id) => {
-                write!(f, "Incorrect id ({} instead of {})", resp_id, sender_id)
+                write!(f, "Incorrect id ({resp_id} instead of {sender_id})")
             }
             CommunicationErrorKind::Unsupported => write!(f, "Operation not supported"),
         }

--- a/src/dynamixel_protocol/v1.rs
+++ b/src/dynamixel_protocol/v1.rs
@@ -147,10 +147,7 @@ impl StatusPacket<PacketV1> for StatusPacketV1 {
         let read_crc = *data.last().unwrap();
         let computed_crc = crc(&data[2..data.len() - 1]);
         if read_crc != computed_crc {
-            println!(
-                "read crc: {}, computed crc: {} data: {:?}",
-                read_crc, computed_crc, data
-            );
+            println!("read crc: {read_crc}, computed crc: {computed_crc} data: {data:?}");
 
             return Err(Box::new(CommunicationErrorKind::ChecksumError));
         }

--- a/src/servo/orbita/orbita3d_poulpe.rs
+++ b/src/servo/orbita/orbita3d_poulpe.rs
@@ -30,12 +30,12 @@ pub struct Vec3d<T> {
 /// Wrapper for a Position/Speed/Load value for each motor
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "python", derive(pyo3::FromPyObject, pyo3::IntoPyObject))]
-
 pub struct MotorPositionSpeedLoad {
     pub position: MotorValue<f32>,
     // pub speed: MotorValue<f32>,
     // pub load: MotorValue<f32>,
 }
+
 /// Wrapper for PID gains.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "python", gen_stub_pyclass, pyo3::pyclass)]


### PR DESCRIPTION
This fixes all the clippy lints that were triggered by default. This was mostly putting variables into format strings, etc. If possible, I would like to deny these lints for the whole crate, but I understand that this may not be desirable to all. I could also try to resolve all or most of the pedantic lints, if that is of interest. :)