### PR TITLE
🐛 Pin pyo3 to 0.27.1 and pyo3-stub-gen to 0.21.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ clap = { version = "4.0.32", features = ["derive"] }
 proc-macro2 = { version = "1.0", features=["default", "proc-macro"] }
 signal-hook = "0.3.4"
 num_enum = "0.7.3"
-pyo3 = { version = ">=0.27.1", optional = true, features = ["multiple-pymethods"] }
+pyo3 = { version = "=0.27.1", optional = true, features = ["multiple-pymethods"] }
 pyo3-log = { version = ">=0.13.2", optional = true }
-pyo3-stub-gen = { version = ">=0.17.0", optional = true }
+pyo3-stub-gen = { version = "=0.21.0", optional = true }
 env_logger = "0.10.0"
 
 [[bin]]


### PR DESCRIPTION
# Summary
Pin pyo3 and pyo3-stub-gen to the last versions compatible with the current macro-generated Python bindings so the python feature builds again.

## Problem
Building with the python feature (e.g. cargo run --bin stub_gen --features python or maturin develop --features python --features pyo3/extension-module) failed with a bunch of errors like:

`error[E0034]: multiple applicable items in scope
   --> src/servo/servo_macro.rs:NNN:22
    |
NNN |   ) -> PyResult<PyObject> {
    |        ^^^^^^^^ multiple `wrap` found
    |
    = note: candidate #1: IntoPyObjectConverter<T>
    = note: candidate #2: IntoPyObjectConverter<Result<T, E>>`

The error came from every macro-expanded controller because generate_servo! produces methods returning PyResult<PyObject>, and newer pyo3 / pyo3-stub-gen don't resolve the conversion properly.

## Cause: the open ranges in Cargo.toml

pyo3 = { version = ">=0.27.1", ... }
pyo3-stub-gen = { version = ">=0.17.0", ... }
resolved to pyo3 0.28.3 and pyo3-stub-gen 0.22.3, which broke the existing macro layer.

## Fix
Pin to the last compatible versions:

pyo3 = { version = "=0.27.1", ... }
pyo3-stub-gen = { version = "=0.21.0", ... }
After this, cargo run --bin stub_gen --features python and maturin develop build cleanly. Default cargo check / cargo test are unaffected.

## Notes
Some deprecation warnings about pyo3::PyObject -> Py<PyAny> remain in the macro layer. They are non-blocking.