### PR TITLE
Add dynamixel fast sync read

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,14 @@
+## Unreleased
+
+- Add fast sync read (protocol v2 instruction 0x8A): every motor appends its answer to a
+  single status packet returned from the broadcast id, instead of each sending its own.
+  Available as `DynamixelProtocolHandler::fast_sync_read`, or by enabling it once with
+  `with_fast_sync_read()` so all `sync_read_*` methods use it. Requires firmware new
+  enough to implement it (XL330: v46+); older firmware does not answer and the read
+  times out.
+- Add the `fast_sync_read_bench` example, which checks both instructions return the same
+  data and times them side by side.
+
 ## Version 1.6.0
 
 - Handle Dynamixel protocol 2.0 byte stuffing: status packets whose data contains FF FF FD are now de-stuffed on reception (previously returned oversized params, breaking fixed-size reads e.g. when present current = -1), and instruction packet params are stuffed on transmission.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Rustypot is a communication library for Dynamixel/Feetech motors. It is notably 
 
 * Relies on [serialport](https://docs.rs/serialport/latest/serialport/) for serial communication
 * Support for dynamixel protocol v1 and v2 (can also use both on the same bus)
-* Support for sync read and sync write operations
+* Support for sync read and sync write operations, plus fast sync read (protocol v2, instruction 0x8A) to read a whole bus in a single status packet
 * Easy support for new type of motors (register definition through macros). Currently support for dynamixel XL320, XL330, XL430, XM430, MX*, AX*, Orbita 2D & 3D.
 * Pure Rust plus python bindings (using [pyo3](https://pyo3.rs/)).
 

--- a/examples/fast_sync_read_bench.rs
+++ b/examples/fast_sync_read_bench.rs
@@ -1,0 +1,402 @@
+//! Compare sync read (0x82) and fast sync read (0x8A) on Dynamixel XL330/XL430 motors.
+//!
+//! Fast sync read sends the same instruction packet as sync read, apart from the
+//! instruction byte itself (0x8A instead of 0x82, and therefore the CRC). It gathers the
+//! same data, but every motor appends its answer to a single status packet returned from
+//! the broadcast id instead of sending its own. That replaces each motor's 11 byte status
+//! packet frame with a 4 byte block (error, id, crc) at the cost of one 8 byte frame for
+//! the whole reply (a net 7n - 8 bytes for n motors) and leaves a single bus
+//! turnaround, with its return delay time, instead of one per motor.
+//!
+//! This example first checks that both instructions return the same bytes, then clocks them
+//! for 1..n motors so the per motor cost of each can be compared against the predicted value.
+//!
+//! ```sh
+//! cargo run --release --example fast_sync_read_bench -- \
+//!     --serialport /dev/tty.usbserial-XXXX --baudrate 1000000 --ids 1,2,3,4,5,6
+//! ```
+//!
+//! Requires protocol v2 firmware implementing fast sync read (e.g. XL330: v46+).
+
+use std::{error::Error, time::Duration, time::Instant};
+
+use clap::Parser;
+use rustypot::DynamixelProtocolHandler;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Serial port (e.g. /dev/ttyUSB0 or /dev/tty.usbmodemXXXX)
+    #[arg(short, long)]
+    serialport: String,
+    /// Baudrate
+    #[arg(short, long, default_value_t = 1_000_000)]
+    baudrate: u32,
+
+    /// Motor ids, comma separated (e.g. 1,2,3,4,5,6)
+    #[arg(short, long, value_delimiter = ',')]
+    ids: Vec<u8>,
+
+    /// First register to read (default 132: present position)
+    #[arg(short, long, default_value_t = 132)]
+    addr: u8,
+
+    /// Number of bytes to read per motor (default 4: one i32)
+    #[arg(short, long, default_value_t = 4)]
+    length: u8,
+
+    /// Timed iterations per measurement
+    #[arg(short = 'n', long, default_value_t = 1000)]
+    iterations: usize,
+
+    /// Untimed iterations before each measurement
+    #[arg(short, long, default_value_t = 50)]
+    warmup: usize,
+
+    /// Only time the full set of ids, skip the 1..n sweep
+    #[arg(long, default_value_t = false)]
+    no_sweep: bool,
+
+    /// Write this return delay time (unit: 2 us) to every motor first, to see how much of
+    /// the difference comes from the cost of one bus turnaround per motor. Writes EEPROM,
+    /// is not restored afterwards. The X series factory default is 250 (500 us).
+    #[arg(long)]
+    return_delay_time: Option<u8>,
+
+    /// Check how both instructions behave when the data contains the FF FF FD pattern
+    #[arg(long, default_value_t = false)]
+    probe_stuffing: bool,
+}
+
+/// Timing of one batch of identical reads.
+struct Stats {
+    mean: f64,
+    p50: f64,
+    p95: f64,
+    errors: usize,
+}
+
+impl Stats {
+    fn of(mut samples: Vec<f64>, errors: usize) -> Self {
+        samples.sort_by(f64::total_cmp);
+        let pct = |p: f64| samples[((samples.len() - 1) as f64 * p) as usize];
+        Stats {
+            mean: samples.iter().sum::<f64>() / samples.len() as f64,
+            p50: pct(0.50),
+            p95: pct(0.95),
+            errors,
+        }
+    }
+}
+
+/// Time `iterations` reads, discarding the ones that failed but counting them.
+fn bench(
+    dph: &DynamixelProtocolHandler,
+    serial_port: &mut dyn serialport::SerialPort,
+    ids: &[u8],
+    args: &Args,
+    fast: bool,
+) -> Stats {
+    let (addr, length) = (args.addr, args.length);
+    let read = |port: &mut dyn serialport::SerialPort| {
+        if fast {
+            dph.fast_sync_read(port, ids, addr, length)
+        } else {
+            dph.sync_read(port, ids, addr, length)
+        }
+    };
+
+    for _ in 0..args.warmup {
+        let _ = read(&mut *serial_port);
+    }
+
+    let mut samples = Vec::with_capacity(args.iterations);
+    let mut errors = 0;
+    for _ in 0..args.iterations {
+        let t = Instant::now();
+        let res = read(&mut *serial_port);
+        let dt = t.elapsed().as_secs_f64() * 1e3;
+        match res {
+            Ok(_) => samples.push(dt),
+            Err(_) => errors += 1,
+        }
+    }
+
+    if samples.is_empty() {
+        samples.push(f64::NAN);
+    }
+    Stats::of(samples, errors)
+}
+
+/// Total bytes the bus carries, instruction plus answers, for `n` motors reading
+/// `length` bytes each. The bus is half duplex, so the two directions cannot overlap
+/// and their sizes simply add, giving the total bus traffic for one transaction
+/// (not counting the return delay time, which is idle bus rather than bytes).
+///
+/// sync read:      instruction 14 + n, then n status packets of 11 + length
+/// fast sync read: instruction 14 + n, then one status packet of 8 + n * (length + 4)
+fn wire_bytes(n: usize, length: u8, fast: bool) -> usize {
+    let instruction = 14 + n;
+    let status = if fast {
+        8 + n * (length as usize + 4)
+    } else {
+        n * (11 + length as usize)
+    };
+    instruction + status
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse();
+    let ids = args.ids.clone();
+    if ids.is_empty() {
+        return Err("no ids given, pass e.g. --ids 1,2,3".into());
+    }
+
+    let mut serial_port = serialport::new(&args.serialport, args.baudrate)
+        .timeout(Duration::from_millis(20))
+        .open()?;
+    let serial_port = serial_port.as_mut();
+
+    let dph = DynamixelProtocolHandler::v2();
+
+    // --- bus inventory -----------------------------------------------------------------
+    println!("bus: {} at {} baud", args.serialport, args.baudrate);
+
+    if let Some(rdt) = args.return_delay_time {
+        for &id in &ids {
+            if dph.read(serial_port, id, 64, 1)?[0] != 0 {
+                return Err(format!("motor {id} has torque enabled, cannot write EEPROM").into());
+            }
+            dph.write(serial_port, id, 9, &[rdt])?;
+        }
+        println!(
+            "return delay time set to {rdt} ({} us) on every motor",
+            rdt as u32 * 2
+        );
+    }
+
+    println!("{:<6}{:<12}{:<12}return delay", "id", "firmware", "model");
+    for &id in &ids {
+        if !dph.ping(serial_port, id)? {
+            return Err(format!("motor {id} did not answer to a ping").into());
+        }
+        let firmware = dph.read(serial_port, id, 6, 1)?[0];
+        let model = u16::from_le_bytes(dph.read(serial_port, id, 0, 2)?.try_into().unwrap());
+        let rdt = dph.read(serial_port, id, 9, 1)?[0];
+        println!(
+            "{:<6}{:<12}{:<12}{} ({} us){}",
+            id,
+            firmware,
+            model,
+            rdt,
+            rdt as u32 * 2,
+            if firmware < 45 {
+                "   <- too old for fast sync read"
+            } else {
+                ""
+            }
+        );
+    }
+    println!();
+
+    // --- correctness -------------------------------------------------------------------
+    // Compared on the first 10 registers, which never change, so both instructions can be
+    // checked against each other without the values moving.
+    let slow = dph.sync_read(serial_port, &ids, 0, 10)?;
+    let fast = dph.fast_sync_read(serial_port, &ids, 0, 10)?;
+    if slow != fast {
+        println!("Mismatch between sync read and fast sync read");
+        for (i, &id) in ids.iter().enumerate() {
+            println!("  id {id}: sync {:02X?} / fast {:02X?}", slow[i], fast[i]);
+        }
+        return Err("fast sync read returned different data".into());
+    }
+    println!(
+        "sync read and fast sync read agree on all {} motors",
+        ids.len()
+    );
+
+    if args.probe_stuffing {
+        probe_stuffing(&dph, serial_port, &ids)?;
+    }
+    println!();
+
+    // --- timing ------------------------------------------------------------------------
+    let byte_us = 10.0 / args.baudrate as f64 * 1e6; // 8N1: 10 bits per byte
+    println!(
+        "reading {} bytes at addr {} per motor, {} iterations each\n",
+        args.length, args.addr, args.iterations
+    );
+    println!(
+        "{:<4}{:>26}{:>26}{:>10}{:>18}",
+        "n", "sync read (ms)", "fast sync read (ms)", "speedup", "wire bytes"
+    );
+    println!(
+        "{:<4}{:>10}{:>8}{:>8}{:>10}{:>8}{:>8}{:>10}{:>18}",
+        "", "mean", "p50", "p95", "mean", "p50", "p95", "mean", "sync -> fast"
+    );
+
+    let counts: Vec<usize> = if args.no_sweep {
+        vec![ids.len()]
+    } else {
+        (1..=ids.len()).collect()
+    };
+
+    for n in counts {
+        let subset = &ids[..n];
+        let s = bench(&dph, serial_port, subset, &args, false);
+        let f = bench(&dph, serial_port, subset, &args, true);
+
+        println!(
+            "{:<4}{:>10.3}{:>8.3}{:>8.3}{:>10.3}{:>8.3}{:>8.3}{:>9.2}x{:>11} -> {:<4}",
+            n,
+            s.mean,
+            s.p50,
+            s.p95,
+            f.mean,
+            f.p50,
+            f.p95,
+            s.mean / f.mean,
+            wire_bytes(n, args.length, false),
+            wire_bytes(n, args.length, true),
+        );
+        if s.errors + f.errors > 0 {
+            println!("      errors: sync {} / fast {}", s.errors, f.errors);
+        }
+    }
+
+    // Bus traffic prediction. Two effects add up: fewer bytes, and fewer status packets
+    // (so fewer return delay times and fewer host side reads).
+    let n = ids.len();
+    let rdt_us = dph.read(serial_port, ids[0], 9, 1)?[0] as f64 * 2.0;
+    let (slow_bytes, fast_bytes) = (
+        wire_bytes(n, args.length, false),
+        wire_bytes(n, args.length, true),
+    );
+    println!("\nwhat the wire format predicts for {n} motors:");
+    println!(
+        "  bytes           {slow_bytes} -> {fast_bytes} ({:.2}x), i.e. {:.3} ms -> {:.3} ms at {} baud",
+        slow_bytes as f64 / fast_bytes as f64,
+        slow_bytes as f64 * byte_us / 1e3,
+        fast_bytes as f64 * byte_us / 1e3,
+        args.baudrate,
+    );
+    println!(
+        "  status packets  {n} -> 1, so {:.3} ms -> {:.3} ms of return delay time ({rdt_us} us each)",
+        n as f64 * rdt_us / 1e3,
+        rdt_us / 1e3,
+    );
+    println!(
+        "  total           {:.3} ms -> {:.3} ms ({:.2}x)",
+        (slow_bytes as f64 * byte_us + n as f64 * rdt_us) / 1e3,
+        (fast_bytes as f64 * byte_us + rdt_us) / 1e3,
+        (slow_bytes as f64 * byte_us + n as f64 * rdt_us) / (fast_bytes as f64 * byte_us + rdt_us),
+    );
+    println!(
+        "  anything measured on top of that is host side: USB turnaround (the FTDI latency\n\
+        \x20 timer, 16 ms unless lowered) and one read syscall per status packet."
+    );
+
+    Ok(())
+}
+
+/// Check what happens when the returned data contains FF FF FD.
+///
+/// A regular status packet is byte stuffed (the motor inserts an extra FD after FF FF FD)
+/// and rustypot undoes that. The official SDK reads fast sync read answers with stuffing
+/// removal explicitly skipped, so it assumes motors do not stuff there. This puts the
+/// pattern in the data on purpose to find out which is true on this firmware.
+///
+/// Goal Velocity (addr 104) set to -1 gives FF FF FF FF and Profile Acceleration
+/// (addr 108) set to 253 gives FD, so addr 104..110 reads FF FF FF FF FD 00. Both are RAM
+/// registers, nothing touches EEPROM, torque stays off so no motor moves, and both are
+/// restored afterwards.
+///
+/// Whether a motor stores those values verbatim depends on its operating mode: a mode that
+/// treats the register as a magnitude or drives it itself will hand back something else.
+/// So the probe reports which motors actually ended up carrying the pattern and only needs
+/// one of them, while still comparing every motor against its own reference read.
+fn probe_stuffing(
+    dph: &DynamixelProtocolHandler,
+    serial_port: &mut dyn serialport::SerialPort,
+    ids: &[u8],
+) -> Result<(), Box<dyn Error>> {
+    println!("\nstuffing probe: putting FF FF FD in the data of every motor");
+
+    for &id in ids {
+        if dph.read(serial_port, id, 64, 1)?[0] != 0 {
+            println!("  skipped: motor {id} has torque enabled, disable it first");
+            return Ok(());
+        }
+    }
+
+    // Goal velocity and profile acceleration, saved together so one write restores both.
+    let saved: Vec<Vec<u8>> = ids
+        .iter()
+        .map(|&id| dph.read(serial_port, id, 104, 8))
+        .collect::<Result<_, _>>()?;
+
+    for &id in ids {
+        dph.write(serial_port, id, 104, &(-1i32).to_le_bytes())?;
+        dph.write(serial_port, id, 108, &253u32.to_le_bytes())?;
+    }
+
+    // One plain read per motor is the reference: it already handles byte
+    // stuffing, and it isolates each motor from the others.
+    let reference: Vec<Vec<u8>> = ids
+        .iter()
+        .map(|&id| dph.read(serial_port, id, 104, 6))
+        .collect::<Result<_, _>>()?;
+    let planted = |d: &Vec<u8>| d.windows(3).any(|w| w == [0xFF, 0xFF, 0xFD]);
+    let carrying: Vec<u8> = ids
+        .iter()
+        .zip(&reference)
+        .filter(|(_, d)| planted(d))
+        .map(|(&id, _)| id)
+        .collect();
+
+    for (&id, d) in ids.iter().zip(&reference) {
+        let mode = dph.read(serial_port, id, 11, 1)?[0];
+        println!(
+            "  id {id} (mode {mode}) reads {d:02X?}{}",
+            if planted(d) { "" } else { "   <- no FF FF FD" }
+        );
+    }
+
+    if !carrying.is_empty() {
+        println!(
+            "  {} of {} motors carry the pattern",
+            carrying.len(),
+            ids.len()
+        );
+
+        match dph.sync_read(serial_port, ids, 104, 6) {
+            Ok(v) if v == reference => println!("  sync read      -> correct, stuffing removed"),
+            Ok(v) => println!("  sync read      -> WRONG: {v:02X?}"),
+            Err(e) => println!("  sync read      -> failed: {e}"),
+        }
+        match dph.fast_sync_read(serial_port, ids, 104, 6) {
+            Ok(v) if v == reference => println!(
+                "  fast sync read -> correct: the answer is not byte stuffed, matching\n\
+                 \x20                 what the official SDK assumes"
+            ),
+            Ok(v) => println!("  fast sync read -> WRONG: {v:02X?}"),
+            Err(e) => println!(
+                "  fast sync read -> failed ({e}): the answer is byte stuffed after all,\n\
+                 \x20                 which the fixed stride parsing does not expect"
+            ),
+        }
+    } else {
+        println!("  skipped: could not get FF FF FD into any motor's data");
+    }
+
+    for (&id, data) in ids.iter().zip(&saved) {
+        // Restore even if something above went wrong, retrying once past a stale bus.
+        if dph.write(serial_port, id, 104, data).is_err() {
+            dph.write(serial_port, id, 104, data)?;
+        }
+    }
+    println!("  goal velocity / profile acceleration restored");
+
+    Ok(())
+}

--- a/src/dynamixel_protocol/mod.rs
+++ b/src/dynamixel_protocol/mod.rs
@@ -14,7 +14,8 @@ use crate::Result;
 #[derive(Debug)]
 enum ProtocolKind {
     V1(V1),
-    V2(V2),
+    /// The bool routes sync reads through fast sync read (protocol v2 only)
+    V2(V2, bool),
 }
 
 #[derive(Debug)]
@@ -73,7 +74,7 @@ impl DynamixelProtocolHandler {
     /// ```
     pub fn v2() -> Self {
         DynamixelProtocolHandler {
-            protocol: ProtocolKind::V2(V2),
+            protocol: ProtocolKind::V2(V2, false),
             post_delay: None,
         }
     }
@@ -84,6 +85,36 @@ impl DynamixelProtocolHandler {
             post_delay: Some(delay),
             ..self
         }
+    }
+
+    /// Make [DynamixelProtocolHandler::sync_read] use Fast Sync Read.
+    ///
+    /// Protocol v2 only, and needs firmware accepting instruction 0x8A (XL330: v46+).
+    /// Ignored on protocol v1.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use rustypot::DynamixelProtocolHandler;
+    ///
+    /// let dph = DynamixelProtocolHandler::v2().with_fast_sync_read();
+    /// ```
+    pub fn with_fast_sync_read(mut self) -> Self {
+        self.set_fast_sync_read(true);
+        self
+    }
+
+    /// Turn the Fast Sync Read routing of [DynamixelProtocolHandler::sync_read] on or off.
+    ///
+    /// Has no effect on protocol v1, which has no such instruction.
+    pub fn set_fast_sync_read(&mut self, enabled: bool) {
+        if let ProtocolKind::V2(_, fast) = &mut self.protocol {
+            *fast = enabled;
+        }
+    }
+
+    /// Whether [DynamixelProtocolHandler::sync_read] currently uses Fast Sync Read.
+    pub fn fast_sync_read_enabled(&self) -> bool {
+        matches!(self.protocol, ProtocolKind::V2(_, true))
     }
 
     /// Send a ping instruction.
@@ -114,7 +145,7 @@ impl DynamixelProtocolHandler {
     pub fn ping(&self, serial_port: &mut dyn serialport::SerialPort, id: u8) -> Result<bool> {
         match &self.protocol {
             ProtocolKind::V1(p) => p.ping(serial_port, id),
-            ProtocolKind::V2(p) => p.ping(serial_port, id),
+            ProtocolKind::V2(p, _) => p.ping(serial_port, id),
         }
     }
 
@@ -125,7 +156,7 @@ impl DynamixelProtocolHandler {
     pub fn reboot(&self, serial_port: &mut dyn serialport::SerialPort, id: u8) -> Result<bool> {
         match &self.protocol {
             ProtocolKind::V1(p) => p.reboot(serial_port, id),
-            ProtocolKind::V2(p) => p.reboot(serial_port, id),
+            ProtocolKind::V2(p, _) => p.reboot(serial_port, id),
         }
     }
 
@@ -147,7 +178,7 @@ impl DynamixelProtocolHandler {
                 }
                 p.factory_reset(serial_port, id, conserve_id_only, conserve_id_and_baudrate)
             }
-            ProtocolKind::V2(p) => {
+            ProtocolKind::V2(p, _) => {
                 p.factory_reset(serial_port, id, conserve_id_only, conserve_id_and_baudrate)
             }
         }
@@ -193,7 +224,7 @@ impl DynamixelProtocolHandler {
     ) -> Result<Vec<u8>> {
         let res = match &self.protocol {
             ProtocolKind::V1(p) => p.read(serial_port, id, addr, length),
-            ProtocolKind::V2(p) => p.read(serial_port, id, addr, length),
+            ProtocolKind::V2(p, _) => p.read(serial_port, id, addr, length),
         };
         if let Some(delay) = self.post_delay {
             std::thread::sleep(delay);
@@ -239,7 +270,7 @@ impl DynamixelProtocolHandler {
     ) -> Result<()> {
         match &self.protocol {
             ProtocolKind::V1(p) => p.write(serial_port, id, addr, data),
-            ProtocolKind::V2(p) => p.write(serial_port, id, addr, data),
+            ProtocolKind::V2(p, _) => p.write(serial_port, id, addr, data),
         }?;
         if let Some(delay) = self.post_delay {
             std::thread::sleep(delay);
@@ -262,7 +293,7 @@ impl DynamixelProtocolHandler {
                 }
                 res
             }
-            ProtocolKind::V2(_) => Err(Box::new(CommunicationErrorKind::Unsupported)),
+            ProtocolKind::V2(..) => Err(Box::new(CommunicationErrorKind::Unsupported)),
         }
     }
 
@@ -312,7 +343,58 @@ impl DynamixelProtocolHandler {
     ) -> Result<Vec<Vec<u8>>> {
         match &self.protocol {
             ProtocolKind::V1(p) => p.sync_read(serial_port, ids, addr, length),
-            ProtocolKind::V2(p) => p.sync_read(serial_port, ids, addr, length),
+            ProtocolKind::V2(p, false) => p.sync_read(serial_port, ids, addr, length),
+            ProtocolKind::V2(p, true) => p.fast_sync_read(serial_port, ids, addr, length),
+        }
+    }
+
+    /// Reads raw register bytes from multiple ids at once, using a single status packet.
+    ///
+    /// Same as [DynamixelProtocolHandler::sync_read], but sends a fast sync read
+    /// instruction (0x8A): every motor appends its answer to one status packet returned
+    /// from the broadcast id, instead of each sending its own. This saves a packet header
+    /// and a bus turnaround (plus its return delay time) per motor.
+    ///
+    /// Protocol v2 only, and only on firmware new enough to implement it (XL330: v46+;
+    /// the cutoff differs per model). Older firmware does not answer, which surfaces as a
+    /// timeout (update the firmware if this occurs).
+    ///
+    /// # Arguments
+    ///
+    /// * `serial_port` - the serial port to use for communication
+    /// * `ids` - specfied motors id
+    /// * `addr` - register address
+    /// * `length` - number of bytes to read
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use rustypot::DynamixelProtocolHandler;
+    /// use std::time::Duration;
+    ///
+    /// let mut serial_port = serialport::new("/dev/ttyUSB0", 1_000_000)
+    ///     .timeout(Duration::from_millis(10))
+    ///     .open()
+    ///     .expect("Failed to open port");
+    ///
+    /// let dph = DynamixelProtocolHandler::v2();
+    ///
+    /// // Read the present position (addr 132, 4 bytes) of motors 10, 11 and 12
+    /// let resp = dph
+    ///     .fast_sync_read(serial_port.as_mut(), &[10, 11, 12], 132, 4)
+    ///     .expect("Communication error");
+    ///
+    /// assert_eq!(resp.len(), 3);
+    /// ```
+    pub fn fast_sync_read(
+        &self,
+        serial_port: &mut dyn serialport::SerialPort,
+        ids: &[u8],
+        addr: u8,
+        length: u8,
+    ) -> Result<Vec<Vec<u8>>> {
+        match &self.protocol {
+            ProtocolKind::V1(_) => Err(Box::new(CommunicationErrorKind::Unsupported)),
+            ProtocolKind::V2(p, _) => p.fast_sync_read(serial_port, ids, addr, length),
         }
     }
 
@@ -356,7 +438,7 @@ impl DynamixelProtocolHandler {
     ) -> Result<()> {
         match &self.protocol {
             ProtocolKind::V1(p) => p.sync_write(serial_port, ids, addr, data),
-            ProtocolKind::V2(p) => p.sync_write(serial_port, ids, addr, data),
+            ProtocolKind::V2(p, _) => p.sync_write(serial_port, ids, addr, data),
         }
     }
 }
@@ -486,11 +568,8 @@ trait Protocol<P: Packet> {
             Err(_) => Err(Box::new(CommunicationErrorKind::TimeoutError)),
         }
     }
-    fn read_status_packet(
-        &self,
-        port: &mut dyn SerialPort,
-        sender_id: u8,
-    ) -> Result<Box<dyn StatusPacket<P>>> {
+    /// Read one status packet off the wire, header included, without interpreting it.
+    fn read_status_packet_bytes(&self, port: &mut dyn SerialPort) -> Result<Vec<u8>> {
         let mut header = vec![0u8; P::HEADER_SIZE];
         port.read_exact(&mut header)?;
 
@@ -504,6 +583,15 @@ trait Protocol<P: Packet> {
 
         // log::debug!("<<< {data:?}");
 
+        Ok(data)
+    }
+
+    fn read_status_packet(
+        &self,
+        port: &mut dyn SerialPort,
+        sender_id: u8,
+    ) -> Result<Box<dyn StatusPacket<P>>> {
+        let data = self.read_status_packet_bytes(port)?;
         P::status_packet(&data, sender_id)
     }
 

--- a/src/dynamixel_protocol/v2.rs
+++ b/src/dynamixel_protocol/v2.rs
@@ -1,3 +1,5 @@
+use serialport::SerialPort;
+
 use crate::Result;
 
 use super::{
@@ -8,6 +10,112 @@ use super::{
 #[derive(Debug)]
 pub(crate) struct V2;
 impl Protocol<PacketV2> for V2 {}
+
+impl V2 {
+    /// Fast Sync Read (instruction 0x8A).
+    ///
+    /// The instruction packet is the same as Sync Read's, but instead of each motor
+    /// answering with its own status packet, every motor appends its answer to a single
+    /// status packet sent from the broadcast id. That saves one packet header plus one
+    /// bus turnaround (and its return delay time) per motor.
+    ///
+    /// Only supported by firmware new enough to implement it (XL330: v46+); older
+    /// firmware does not answer and the read times out.
+    pub(crate) fn fast_sync_read(
+        &self,
+        port: &mut dyn SerialPort,
+        ids: &[u8],
+        addr: u8,
+        length: u8,
+    ) -> Result<Vec<Vec<u8>>> {
+        self.send_instruction_packet(
+            port,
+            PacketV2::fast_sync_read_packet(ids, addr, length).as_ref(),
+        )?;
+        let data = self.read_status_packet_bytes(port)?;
+        parse_fast_sync_read_status(&data, ids, length)
+    }
+}
+
+impl PacketV2 {
+    /// Same parameters as [`PacketV2::sync_read_packet`], only the instruction differs.
+    fn fast_sync_read_packet(
+        ids: &[u8],
+        addr: u8,
+        length: u8,
+    ) -> Box<dyn InstructionPacket<PacketV2>> {
+        Box::new(InstructionPacketV2 {
+            id: BROADCAST_ID,
+            instruction: InstructionKindV2::FastSyncRead,
+            params: {
+                let mut params = Vec::new();
+                params.extend((addr as u16).to_le_bytes());
+                params.extend((length as u16).to_le_bytes());
+                params.extend(ids);
+                params
+            },
+        })
+    }
+}
+
+/// Split the single status packet answering a Fast Sync Read into one data slice per id.
+///
+/// After the usual `FF FF FD 00 FE LEN_L LEN_H 0x55` header, the body is one fixed size
+/// block per requested id, in the order they were requested:
+///
+/// ```text
+/// [ERROR ID DATA(length) CRC_L CRC_H] x nb_ids
+/// ```
+///
+/// The CRC a motor appends is the CRC accumulated over the whole packet up to and
+/// including its own block, so the last one is also the CRC of the complete packet.
+/// Checking every block's CRC therefore validates the packet *and* tells us the blocks
+/// sit where we think they do.
+///
+/// Note: unlike a regular status packet, the body is not de-stuffed. The official SDK
+/// reads these packets with stuffing removal explicitly skipped
+/// (`GroupFastSyncRead::rxPacket` calls `rxPacket(.., skip_stuffing = true)`) and walks
+/// the body with a fixed stride, i.e. it assumes motors do not insert stuffing bytes
+/// here. We do the same, but the per block CRC check above means a stuffed byte would
+/// be reported as a checksum error rather than silently shifting the data.
+fn parse_fast_sync_read_status(data: &[u8], ids: &[u8], length: u8) -> Result<Vec<Vec<u8>>> {
+    // Header + the 0x55 marking a status packet
+    const BODY_START: usize = PacketV2::HEADER_SIZE + 1;
+    // ERROR + ID + DATA + CRC16
+    let block_size = length as usize + 4;
+
+    if data.len() != BODY_START + ids.len() * block_size {
+        return Err(Box::new(CommunicationErrorKind::ParsingError));
+    }
+    if data[4] != BROADCAST_ID || data[7] != 0x55 {
+        return Err(Box::new(CommunicationErrorKind::ParsingError));
+    }
+    let payload_length = u16::from_le_bytes(data[5..7].try_into().unwrap()) as usize;
+    if payload_length != data.len() - PacketV2::HEADER_SIZE {
+        return Err(Box::new(CommunicationErrorKind::ParsingError));
+    }
+
+    let mut values = Vec::with_capacity(ids.len());
+    for (i, &id) in ids.iter().enumerate() {
+        let block = BODY_START + i * block_size;
+        let crc_at = block + 2 + length as usize;
+
+        let read_crc = u16::from_le_bytes(data[crc_at..crc_at + 2].try_into().unwrap());
+        if read_crc != crc(&data[..crc_at]) {
+            return Err(Box::new(CommunicationErrorKind::ChecksumError));
+        }
+        if data[block + 1] != id {
+            return Err(Box::new(CommunicationErrorKind::IncorrectId(
+                id,
+                data[block + 1],
+            )));
+        }
+
+        values.push(data[block + 2..crc_at].to_vec());
+    }
+
+    Ok(values)
+}
 
 #[derive(Debug)]
 pub(crate) struct PacketV2;
@@ -310,6 +418,7 @@ pub(crate) enum InstructionKindV2 {
     Reboot,
     SyncRead,
     SyncWrite,
+    FastSyncRead,
 }
 
 impl InstructionKindV2 {
@@ -322,6 +431,7 @@ impl InstructionKindV2 {
             InstructionKindV2::Reboot => 0x08,
             InstructionKindV2::SyncRead => 0x82,
             InstructionKindV2::SyncWrite => 0x83,
+            InstructionKindV2::FastSyncRead => 0x8A,
         }
     }
 }
@@ -556,6 +666,66 @@ mod tests {
         assert_eq!(sp.id, 1);
         assert_eq!(sp.errors.len(), 0);
         assert_eq!(sp.params, [0xFF, 0xFF, 0xFD, 0xA6]);
+    }
+
+    #[test]
+    fn create_fast_sync_read_packet() {
+        // Same bytes as a sync read, with instruction 0x82 -> 0x8A.
+        let p = PacketV2::fast_sync_read_packet(&[1, 2], 132, 4);
+        let bytes = p.to_bytes();
+        assert_eq!(bytes[7], 0x8A);
+        assert_eq!(bytes[..7], [0xFF, 0xFF, 0xFD, 0x00, 0xFE, 0x09, 0x00]);
+        assert_eq!(bytes[8..12], [0x84, 0x00, 0x04, 0x00]);
+        assert_eq!(bytes[12..14], [0x01, 0x02]);
+        assert_eq!(crc(&bytes[..bytes.len() - 2]).to_le_bytes(), bytes[14..]);
+    }
+
+    /// Example status packet from the protocol 2.0 e-manual: ids 3, 7 and 4 answering a
+    /// fast sync read of present position (addr 132, 4 bytes).
+    /// <https://docs.robotis.com/docs/dxl/protocol/protocol2/#fast-sync-read-0x8a>
+    const FAST_SYNC_READ_STATUS: [u8; 32] = [
+        0xFF, 0xFF, 0xFD, 0x00, 0xFE, 0x19, 0x00, 0x55, //
+        0x00, 0x03, 0xA6, 0x00, 0x00, 0x00, 0x84, 0x08, //
+        0x00, 0x07, 0x1F, 0x08, 0x00, 0x00, 0x16, 0xCA, //
+        0x00, 0x04, 0xFF, 0x03, 0x00, 0x00, 0xD1, 0x9E,
+    ];
+
+    #[test]
+    fn parse_fast_sync_read_status_packet() {
+        let values = parse_fast_sync_read_status(&FAST_SYNC_READ_STATUS, &[3, 7, 4], 4).unwrap();
+
+        assert_eq!(values.len(), 3);
+        assert_eq!(values[0], [0xA6, 0x00, 0x00, 0x00]); // id 3: 166
+        assert_eq!(values[1], [0x1F, 0x08, 0x00, 0x00]); // id 7: 2079
+        assert_eq!(values[2], [0xFF, 0x03, 0x00, 0x00]); // id 4: 1023
+    }
+
+    #[test]
+    fn fast_sync_read_blocks_carry_a_running_crc() {
+        // Every block ends with the CRC of the packet up to that point, so the last one
+        // is the CRC of the whole packet. This is what lets us check block alignment.
+        for (block_end, expected) in [(14, [0x84, 0x08]), (22, [0x16, 0xCA]), (30, [0xD1, 0x9E])] {
+            assert_eq!(
+                crc(&FAST_SYNC_READ_STATUS[..block_end]).to_le_bytes(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn reject_corrupted_fast_sync_read_status_packet() {
+        // A wrong number of ids for that packet size
+        assert!(parse_fast_sync_read_status(&FAST_SYNC_READ_STATUS, &[3, 7], 4).is_err());
+        // Ids answering in an order we did not ask for
+        assert!(parse_fast_sync_read_status(&FAST_SYNC_READ_STATUS, &[3, 4, 7], 4).is_err());
+
+        // A flipped data byte breaks that block's CRC (and every one after it)
+        let mut corrupted = FAST_SYNC_READ_STATUS;
+        corrupted[10] ^= 0x01;
+        assert!(parse_fast_sync_read_status(&corrupted, &[3, 7, 4], 4).is_err());
+
+        // A missing motor: the packet is one block short of what we asked for
+        assert!(parse_fast_sync_read_status(&FAST_SYNC_READ_STATUS[..24], &[3, 7, 4], 4).is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! * Relies on [serialport] for serial communication
 //! * Support for dynamixel protocol v1 and v2 (both can be used on the same io)
-//! * Support for sync read and sync write operations
+//! * Support for sync read and sync write operations, plus fast sync read (protocol v2)
 //! * Easy support for new type of motors (register definition through macros)
 //! * Pure Rust
 //!

--- a/src/servo/servo_macro.rs
+++ b/src/servo/servo_macro.rs
@@ -95,7 +95,39 @@ macro_rules! generate_protocol_constructor {
                         ..self
                     }
                 }
+
+                /// Answer every `sync_read_*` with a fast sync read (instruction 0x8A).
+                ///
+                /// All motors then append their answer to a single status packet instead
+                /// of sending one each, which saves a packet header and a bus turnaround
+                /// per motor. Needs firmware new enough to implement it (XL330: v46+);
+                /// older firmware does not answer and the read times out.
+                pub fn with_fast_sync_read(self) -> Self {
+                    let dph = self
+                        .dph
+                        .unwrap_or_else($crate::DynamixelProtocolHandler::v2);
+                    Self {
+                        dph: Some(dph.with_fast_sync_read()),
+                        ..self
+                    }
+                }
+
+                /// Turn the fast sync read routing of the `sync_read_*` methods on or off.
+                pub fn set_fast_sync_read(&mut self, enabled: bool) {
+                    self.dph.as_mut().unwrap().set_fast_sync_read(enabled);
+                }
             }
+
+            #[cfg(feature = "python")]
+            #[gen_stub_pymethods]
+            #[pymethods]
+            impl [<$servo_name:camel PyController>] {
+                /// Turn the fast sync read routing of the `sync_read_*` methods on or off.
+                pub fn set_fast_sync_read(&self, enabled: bool) {
+                    self.0.lock().unwrap().set_fast_sync_read(enabled);
+                }
+            }
+
             #[cfg(feature = "python")]
             #[gen_stub_pymethods]
             #[pymethods]


### PR DESCRIPTION
Implements Dynamixel fast sync read, an upgraded version of sync read which uses the same outgoing command as Dynamixel sync read with a different instruction (`0x8A` vs `0x82`).

Basically always faster with no downside but marginal benefits in typical RL applications (50Hz). Useful when bitrate is restricted, when trying to collect the maximum amount of data per tick (e.g. when doing Dynamixel indirect address/data packing), or when collecting data at higher frequencies (250-500Hz).

Code written by Claude, reviewed by me (I don't write much Rust but it seems fine). I went through all the code comments and streamlined them to your standard. 

## TLDR
- Strictly fewer bytes and fewer packets with 2+ servos (edge case: 1 servo, 1 extra byte)
- allows return delay time to be configured above minimum, because all servos answer in one status packet, so return delays do not compound with n_servos
- reply carries cumulative per-block CRCs (qualitatively different, but seems fine)
- reply is not byte stuffed, unlike regular status packets (noted since #121 added stuffing handling for regular packets)
- may need a firmware update (XL330: v46+, but any shipped 2022+(?) servo should have this)
- opt-in and off by default

## Usage
```rust
// low level, explicit
dph.fast_sync_read(serial_port, &ids, 132, 4)?;

// or route every generated sync_read_* through it
let mut c = Xl330Controller::new().with_fast_sync_read().with_serial_port(port);
let pos = c.sync_read_present_position(&ids)?;   // now uses 0x8A
```

Python gets `set_fast_sync_read(bool)`, which reroutes the existing `sync_read_*` methods rather than adding per-register bindings.

## Savings details (n = number of servos)
`7n - 8` bytes, independent of how many bytes you read, because it replaces each motor's 11-byte status packet frame with a 4-byte block at the cost of one 8-byte frame for the whole reply. It also collapses n bus turnarounds into one, so you pay one return delay time instead of n.

Savings depend on the update frequency and the host's serial latency, and these savings are a fixed number of bytes plus `(n-1)` return delays. The host that I sampled with had a 2ms USB latency, so that's the floor.

At the factory default return delay time (250 = 500 us), recorded on 1/3/7x XL330 at 1 Mbps reading one value (present position):

| n_servos | sync read | fast sync read | speedup |
|---|---|---|---|
| 1 | 2.00 ms | 2.00 ms | 1.00x |
| 3 | 4.00 ms | 2.00 ms | 2.00x |
| 7 | 6.00 ms | 2.00 ms | 2.99x |

The remaining wire saving (41 bytes at n_servos = 7, or 0.41 ms at 1 Mbps) is smaller than my host's USB latency granularity, so it is invisible unless it moves across a bucket (e.g. 2 ms → 4 ms). Setting return delay time to zero:

| bytes/servo | sync read | fast sync read | speedup |
|---|---|---|---|
| 4 | 2.00 ms | 2.00 ms | 1.00x |
| 10 | 3.93 ms | 2.00 ms | 1.96x |
| 28 | 4.00 ms | 4.00 ms | 1.00x |

Note: 28 bytes corresponds to the full indirect data buffer available to the XL330, which is a realistic upper bound for that data acquired from a Dynamixel at each frame.

## Compatibility

Purely additive: new methods and no signature changes. The flag lives on the private `ProtocolKind::V2` variant, so a v1 handler cannot represent it and nothing outside the crate can observe the change. Verified by compiling an existing downstream consumer (a robot control crate using `Xl330Controller`) against this branch unmodified.

## Testing

- 4 unit tests: parsing the Dynamixel e-manual's example packet, the running-CRC property, rejecting corrupted / misaligned / truncated replies, and packet construction (verifying the instruction packet is the same as sync read's except for 0x82 → 0x8A)
- Hardware (7x XL330, fw v53): sync read and fast sync read return the same data on every run, across read lengths of 1-28 bytes
- Python bindings verified end-to-end in a clean venv against the same motors as above
- `cargo test`, `cargo clippy`, `cargo fmt --check` clean; `--features python` builds and stub generation picks up the new method
- `examples/fast_sync_read_bench.rs` reproduces all numbers above
