### PR TITLE
Expose servo control table registers and use them in a dynamixel indirect addressing example

### DIFF
--- a/examples/indirect_addressing.rs
+++ b/examples/indirect_addressing.rs
@@ -1,0 +1,417 @@
+//! Gather non-contiguous registers into one contiguous read using indirect addressing.
+//!
+//! A control loop may want a handful of registers that are not contiguous.
+//! Reading them costs either one transaction per group, or one wide read that drags along
+//! every byte in between. Indirect addressing solves this by pointing a block of
+//! indirect address slots at the bytes you actually want, and they appear contiguously in
+//! the indirect data region, so one short read returns exactly your registers.
+//!
+//! This example uses `realtime_tick` (120, 2 bytes) and `present_position` (132, 4 bytes)
+//! as the per tick block, and `present_input_voltage` (144, 2 bytes) as a slower one, then
+//! compares three ways of reading them. The slow registers are intentionally mapped after
+//! the fast ones, so the same read can cover 6 bytes on a normal tick or 8 when the slow
+//! values are wanted. In this example, the base address never changes, only the length,
+//! although the slow block can be read separately if desired.
+//!
+//! ```sh
+//! cargo run --release --example indirect_addressing -- \
+//!     --serialport /dev/tty.usbserial-XXXX --ids 1,2,3,4,5,6
+//! ```
+//!
+//! Two notes before considering indirect mapping:
+//!
+//! * An indirect address may only point at the RAM area (address 64 and up). Pointing one
+//!   at EEPROM is rejected by the servo, and because rustypot discards the status packet's
+//!   error byte the write returns `Ok` while quietly doing nothing -- so always read the
+//!   table back, as this example does.
+//! * Indirect addresses live in RAM themselves, so the map is lost on every power cycle
+//!   and has to be reapplied at startup.
+//!
+//! Requires protocol v2 firmware with indirect data at 224 (XL330: v53+; earlier firmware
+//! puts it at 208). This example restores whatever map it found when it exits.
+
+use std::{error::Error, time::Duration, time::Instant};
+
+use clap::Parser;
+use rustypot::{servo::dynamixel::xl330, DynamixelProtocolHandler};
+
+/// Where the two indirect blocks start: `indirect_address_1` is the first pointer slot,
+/// `indirect_data_1` the first byte they gather into.
+fn indirect_bases() -> Result<(u8, u8, u8), Box<dyn Error>> {
+    let addr =
+        xl330::register("indirect_address_1").ok_or("this servo defines no indirect_address_1")?;
+    let data = xl330::register("indirect_data_1").ok_or("this servo defines no indirect_data_1")?;
+    // Each pointer slot is one u16, which is what indirect_map writes per byte gathered.
+    Ok((addr.addr, data.addr, addr.size))
+}
+
+/// Registers used to prove the gather is correct without racing live values: in RAM,
+/// constant in practice, and not adjacent to each other.
+const CONST_REGS: &[&str] = &["torque_enable", "status_return_level", "position_p_gain"];
+
+/// Resolve register names to (address, size) through the servo's own register table, so
+/// the map can be chosen at runtime instead of hardcoded.
+fn resolve(names: &[impl AsRef<str>]) -> Result<Vec<(u8, u8)>, Box<dyn Error>> {
+    names
+        .iter()
+        .map(|n| {
+            let n = n.as_ref();
+            let r = xl330::register(n).ok_or_else(|| {
+                format!(
+                    "unknown register {n:?} ({} are defined)",
+                    xl330::REGISTERS.len()
+                )
+            })?;
+            // Indirect addresses can only point at RAM. The servo rejects anything lower,
+            // and the write reports Ok while doing nothing, so catch it here instead.
+            if r.addr < 64 {
+                return Err(format!(
+                    "{n} is at {} in EEPROM; indirect addressing only reaches RAM (64+)",
+                    r.addr
+                )
+                .into());
+            }
+            Ok((r.addr, r.size))
+        })
+        .collect()
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// tty
+    #[arg(short, long, default_value = "/dev/ttyUSB0")]
+    serialport: String,
+    /// baud
+    #[arg(short, long, default_value_t = 1_000_000)]
+    baudrate: u32,
+    /// Motor ids to read
+    #[arg(short, long, value_delimiter = ',')]
+    ids: Vec<u8>,
+    /// Registers to gather every tick, by name
+    #[arg(
+        long,
+        value_delimiter = ',',
+        default_value = "realtime_tick,present_position"
+    )]
+    fast: Vec<String>,
+    /// Registers appended for the occasional slower read
+    #[arg(long, value_delimiter = ',', default_value = "present_input_voltage")]
+    slow: Vec<String>,
+    /// Timed iterations per measurement
+    #[arg(short = 'n', long, default_value_t = 500)]
+    iterations: usize,
+    /// Untimed iterations before each measurement
+    #[arg(short, long, default_value_t = 30)]
+    warmup: usize,
+}
+
+/// Build the indirect address table for `entries`.
+///
+/// Each slot points at exactly ONE byte, so an n byte register needs n consecutive slots
+/// pointing at addr, addr+1, ... This part is easy to get wrong by hand.
+fn indirect_map(entries: &[(u8, u8)]) -> Vec<u8> {
+    entries
+        .iter()
+        .flat_map(|&(addr, len)| (0..len).map(move |i| addr as u16 + i as u16))
+        .flat_map(|a| a.to_le_bytes())
+        .collect()
+}
+
+fn block_len(entries: &[(u8, u8)]) -> u8 {
+    entries.iter().map(|&(_, len)| len).sum()
+}
+
+/// Bytes on the bus for one sync read of `len` bytes from `n` motors.
+fn wire_bytes(n: usize, len: u8, fast: bool) -> usize {
+    let instruction = 14 + n;
+    let status = if fast {
+        8 + n * (len as usize + 4)
+    } else {
+        n * (11 + len as usize)
+    };
+    instruction + status
+}
+
+/// One transaction per register group, then stitch each motor's bytes back together.
+fn read_separate(
+    dph: &DynamixelProtocolHandler,
+    port: &mut dyn serialport::SerialPort,
+    ids: &[u8],
+    groups: &[(u8, u8)],
+) -> Result<Vec<Vec<u8>>, Box<dyn Error>> {
+    let mut out = vec![Vec::new(); ids.len()];
+    for &(addr, len) in groups {
+        for (slot, data) in out.iter_mut().zip(dph.sync_read(port, ids, addr, len)?) {
+            slot.extend(data);
+        }
+    }
+    Ok(out)
+}
+
+/// One wide read covering everything, including unwanted bytes.
+fn read_wide(
+    dph: &DynamixelProtocolHandler,
+    port: &mut dyn serialport::SerialPort,
+    ids: &[u8],
+    groups: &[(u8, u8)],
+    wide_addr: u8,
+    wide_len: u8,
+) -> Result<Vec<Vec<u8>>, Box<dyn Error>> {
+    let blocks = dph.sync_read(port, ids, wide_addr, wide_len)?;
+    Ok(blocks
+        .iter()
+        .map(|b| {
+            groups
+                .iter()
+                .flat_map(|&(addr, len)| {
+                    let off = (addr - wide_addr) as usize;
+                    b[off..off + len as usize].to_vec()
+                })
+                .collect()
+        })
+        .collect())
+}
+
+fn mean_ms(
+    mut f: impl FnMut() -> Result<(), Box<dyn Error>>,
+    warmup: usize,
+    iterations: usize,
+) -> (f64, usize) {
+    for _ in 0..warmup {
+        let _ = f();
+    }
+    let mut errors = 0;
+    let t = Instant::now();
+    for _ in 0..iterations {
+        if f().is_err() {
+            errors += 1;
+        }
+    }
+    (t.elapsed().as_secs_f64() * 1e3 / iterations as f64, errors)
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse();
+    let ids = args.ids.clone();
+    if ids.is_empty() {
+        return Err("no ids given, pass e.g. --ids 1,2,3".into());
+    }
+    let n = ids.len();
+
+    let mut serial_port = serialport::new(&args.serialport, args.baudrate)
+        .timeout(Duration::from_millis(30))
+        .open()?;
+    let port = serial_port.as_mut();
+
+    let dph = DynamixelProtocolHandler::v2();
+    let fast_dph = DynamixelProtocolHandler::v2().with_fast_sync_read();
+
+    let (indirect_addr, indirect_data, slot_size) = indirect_bases()?;
+
+    let fast_regs = resolve(&args.fast)?;
+    let slow_regs = resolve(&args.slow)?;
+    let const_regs = resolve(CONST_REGS)?;
+    let all: Vec<(u8, u8)> = fast_regs.iter().chain(&slow_regs).copied().collect();
+    let map = indirect_map(&all);
+    let (fast_len, all_len) = (block_len(&fast_regs), block_len(&all));
+
+    // What a single contiguous read would have to span to reach every chosen register.
+    let wide_addr = all.iter().map(|&(a, _)| a).min().unwrap();
+    let wide_len = all.iter().map(|&(a, l)| a + l).max().unwrap() - wide_addr;
+
+    println!(
+        "bus: {} at {} baud, {n} motors",
+        args.serialport, args.baudrate
+    );
+    for &id in &ids {
+        let fw = dph.read(port, id, 6, 1)?[0];
+        if fw < 53 {
+            println!("  motor {id} firmware v{fw}: indirect data is at 208 below v53, not 224");
+        }
+    }
+    println!("  indirect address slots at {indirect_addr}, gathered data at {indirect_data}");
+    println!(
+        "\nmapping {all_len} bytes into indirect data: fast {:?} then slow {:?}\n  \
+         a single contiguous read would need {wide_len} bytes from {wide_addr}",
+        args.fast, args.slow
+    );
+
+    // --- correctness, on registers that cannot change under us --------------------
+    let saved: Vec<Vec<u8>> = ids
+        .iter()
+        .map(|&id| dph.read(port, id, indirect_addr, map.len() as u8))
+        .collect::<Result<_, _>>()?;
+
+    dph.sync_write(
+        port,
+        &ids,
+        indirect_addr,
+        &vec![indirect_map(&const_regs); n],
+    )?;
+    let direct = read_separate(&dph, port, &ids, &const_regs)?;
+    let gathered = dph.sync_read(port, &ids, indirect_data, block_len(&const_regs))?;
+    if direct != gathered {
+        println!("  direct   {direct:02X?}\n  indirect {gathered:02X?}");
+        return Err("indirect data does not match direct reads".into());
+    }
+    println!(
+        "\ngathered {CONST_REGS:?} through indirect data: matches direct reads on all {n} motors"
+    );
+
+    // --- writing the real map -------------------------------------------------------
+    // Indirect Address 1..N is contiguous, so the whole table for every motor fits in one
+    // sync write. A slot at a time costs n * slots transactions, each awaiting a status
+    // packet, which is what makes the difference so large.
+    // Both paths finish with the same read back, so the timings are comparable: a sync
+    // write gets no status packet, so without it the measurement would only capture the
+    // host queueing bytes rather than the servos applying them.
+    let confirm = |port: &mut dyn serialport::SerialPort| {
+        dph.read(port, ids[n - 1], indirect_addr, map.len() as u8)
+    };
+
+    let t = Instant::now();
+    for &id in &ids {
+        for (slot, chunk) in map.chunks(2).enumerate() {
+            dph.write(port, id, indirect_addr + slot_size * slot as u8, chunk)?;
+        }
+    }
+    confirm(port)?;
+    let per_slot = t.elapsed().as_secs_f64() * 1e3;
+
+    // Put the table back so the batched write has the same work to do.
+    dph.sync_write(
+        port,
+        &ids,
+        indirect_addr,
+        &vec![indirect_map(&const_regs); n],
+    )?;
+    confirm(port)?;
+
+    let t = Instant::now();
+    dph.sync_write(port, &ids, indirect_addr, &vec![map.clone(); n])?;
+    let landed = confirm(port)?;
+    let batched = t.elapsed().as_secs_f64() * 1e3;
+
+    // The servo rejects an out of range target silently, so check rather than trust Ok.
+    if landed != map {
+        return Err(format!("map did not land: wrote {map:02X?}, read {landed:02X?}").into());
+    }
+
+    // A single register write is 14 bytes out and an 11 byte status back. A sync write
+    // carries every motor's table in one packet and gets no status at all.
+    let slots = map.len() / 2;
+    let per_slot_bytes = n * slots * (14 + 11);
+    let batched_bytes = 14 + n * (1 + map.len());
+
+    println!("\nwriting the {slots}-slot map to {n} motors (each timing includes one read back):");
+    println!(
+        "{:<34}{:>10}{:>12}{:>14}",
+        "", "mean (ms)", "wire bytes", "transactions"
+    );
+    println!(
+        "{:<34}{per_slot:>10.2}{per_slot_bytes:>12}{:>14}",
+        "  one write per slot",
+        n * slots
+    );
+    println!(
+        "{:<34}{batched:>10.2}{batched_bytes:>12}{:>14}",
+        "  one sync write", 1
+    );
+    println!(
+        "  -> {:.0}x faster, {:.0}x fewer bytes",
+        per_slot / batched,
+        per_slot_bytes as f64 / batched_bytes as f64
+    );
+
+    // Sanity check the live map landed, and show what it reads. The block layout follows
+    // whichever registers were asked for, so walk it rather than assuming offsets.
+    let indirect = dph.sync_read(port, &ids, indirect_data, all_len)?;
+    let names = args.fast.iter().chain(&args.slow);
+    let mut off = 0;
+    print!("  id {} reads", ids[0]);
+    for (name, &(_, len)) in names.zip(&all) {
+        let bytes = &indirect[0][off..off + len as usize];
+        let value = bytes
+            .iter()
+            .rev()
+            .fold(0u32, |acc, &b| (acc << 8) | b as u32);
+        print!("  {name} {value}");
+        off += len as usize;
+    }
+    println!();
+
+    // --- timing -----------------------------------------------------------------------
+    println!(
+        "\n{:<34}{:>10}{:>12}{:>14}",
+        "", "mean (ms)", "wire bytes", "transactions"
+    );
+    let separate_bytes = |fast: bool| {
+        all.iter()
+            .map(|&(_, l)| wire_bytes(n, l, fast))
+            .sum::<usize>()
+    };
+
+    for (label, fast) in [("sync read", false), ("fast sync read", true)] {
+        let d = if fast { &fast_dph } else { &dph };
+        println!("{label}:");
+
+        let (ms, _) = mean_ms(
+            || read_separate(d, port, &ids, &all).map(|_| ()),
+            args.warmup,
+            args.iterations,
+        );
+        println!(
+            "{:<34}{ms:>10.3}{:>12}{:>14}",
+            "  one read per register",
+            separate_bytes(fast),
+            all.len()
+        );
+
+        let (ms, _) = mean_ms(
+            || read_wide(d, port, &ids, &all, wide_addr, wide_len).map(|_| ()),
+            args.warmup,
+            args.iterations,
+        );
+        println!(
+            "{:<34}{ms:>10.3}{:>12}{:>14}",
+            &format!("  one wide read ({wide_len} B)"),
+            wire_bytes(n, wide_len, fast),
+            1
+        );
+
+        let (ms, _) = mean_ms(
+            || d.sync_read(port, &ids, indirect_data, all_len).map(|_| ()),
+            args.warmup,
+            args.iterations,
+        );
+        println!(
+            "{:<34}{ms:>10.3}{:>12}{:>14}",
+            &format!("  indirect, fast+slow ({all_len} B)"),
+            wire_bytes(n, all_len, fast),
+            1
+        );
+
+        let (ms, _) = mean_ms(
+            || d.sync_read(port, &ids, indirect_data, fast_len).map(|_| ()),
+            args.warmup,
+            args.iterations,
+        );
+        println!(
+            "{:<34}{ms:>10.3}{:>12}{:>14}",
+            &format!("  indirect, fast only ({fast_len} B)"),
+            wire_bytes(n, fast_len, fast),
+            1
+        );
+    }
+
+    // --- restore ----------------------------------------------------------------------
+    for (&id, data) in ids.iter().zip(&saved) {
+        if dph.write(port, id, indirect_addr, data).is_err() {
+            dph.write(port, id, indirect_addr, data)?;
+        }
+    }
+    println!("\nindirect address table restored");
+
+    Ok(())
+}

--- a/src/servo/mod.rs
+++ b/src/servo/mod.rs
@@ -1,5 +1,20 @@
 pub mod conversion;
 
+/// Where a register exists in a servo's control table.
+///
+/// Each servo module exposes its full table as `REGISTERS`, which lets callers work with
+/// registers chosen at runtime (building an indirect address map, or a config tool that
+/// takes register names) without hardcoding addresses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RegisterInfo {
+    /// Register name, matching the generated accessor (`present_position` -> `read_present_position`).
+    pub name: &'static str,
+    /// Address in the control table.
+    pub addr: u8,
+    /// Size in bytes.
+    pub size: u8,
+}
+
 pub mod dynamixel;
 pub mod feetech;
 pub mod orbita;

--- a/src/servo/servo_macro.rs
+++ b/src/servo/servo_macro.rs
@@ -342,7 +342,7 @@ macro_rules! generate_reg_access {
 macro_rules! generate_reg_read {
     ($servo_name:ident, $reg_name:ident, $reg_addr:expr, $reg_type:ty, None) => {
         paste::paste! {
-            #[doc = concat!("Read register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+            #[doc = concat!("Read register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
             pub fn [<read_ $reg_name>](
                 io: &$crate::DynamixelProtocolHandler,
                 serial_port: &mut dyn serialport::SerialPort,
@@ -354,7 +354,7 @@ macro_rules! generate_reg_read {
                 Ok(val)
             }
 
-            #[doc = concat!("Sync read register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+            #[doc = concat!("Sync read register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
             pub fn [<sync_read_ $reg_name>](
                 io: &$crate::DynamixelProtocolHandler,
                 serial_port: &mut dyn serialport::SerialPort,
@@ -370,7 +370,7 @@ macro_rules! generate_reg_read {
             }
 
             impl [<$servo_name:camel Controller>] {
-                #[doc = concat!("Sync read register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Sync read register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<sync_read_ $reg_name>](
                     &mut self,
                     ids: &[u8],
@@ -385,7 +385,7 @@ macro_rules! generate_reg_read {
 
 
             impl [<$servo_name:camel Controller>] {
-                #[doc = concat!("Read register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Read register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<read_ $reg_name>](
                     &mut self,
                     id: u8,
@@ -407,6 +407,7 @@ macro_rules! generate_reg_read {
             #[gen_stub_pymethods]
             #[pymethods]
             impl [<$servo_name:camel PyController>] {
+                #[doc = concat!("Sync read register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<sync_read_ $reg_name>](
                     &self,
                     py: Python,
@@ -427,6 +428,7 @@ macro_rules! generate_reg_read {
             #[gen_stub_pymethods]
             #[pymethods]
             impl [<$servo_name:camel PyController>] {
+                #[doc = concat!("Read register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<read_ $reg_name>](
                     &self,
                     py: Python,
@@ -446,7 +448,7 @@ macro_rules! generate_reg_read {
     };
     ($servo_name:ident, $reg_name:ident, $reg_addr:expr, $reg_type:ty, $conv:ident) => {
         paste::paste! {
-            #[doc = concat!("Read register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+            #[doc = concat!("Read raw register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
             pub fn [<read_raw_ $reg_name>](
                 io: &$crate::DynamixelProtocolHandler,
                 serial_port: &mut dyn serialport::SerialPort,
@@ -458,6 +460,7 @@ macro_rules! generate_reg_read {
                 Ok(val)
             }
 
+            #[doc = concat!("Read register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", converted by ", stringify!($conv), ")")]
             pub fn [<read_ $reg_name>](
                 io: &$crate::DynamixelProtocolHandler,
                 serial_port: &mut dyn serialport::SerialPort,
@@ -468,7 +471,7 @@ macro_rules! generate_reg_read {
                 Ok(val)
             }
 
-            #[doc = concat!("Sync read register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+            #[doc = concat!("Sync read raw register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
             pub fn [<sync_read_raw_ $reg_name>](
                 io: &$crate::DynamixelProtocolHandler,
                 serial_port: &mut dyn serialport::SerialPort,
@@ -483,6 +486,7 @@ macro_rules! generate_reg_read {
                 Ok(val)
             }
 
+            #[doc = concat!("Sync read register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", converted by ", stringify!($conv), ")")]
             pub fn [<sync_read_ $reg_name>](
                 io: &$crate::DynamixelProtocolHandler,
                 serial_port: &mut dyn serialport::SerialPort,
@@ -498,7 +502,7 @@ macro_rules! generate_reg_read {
             }
 
             impl [<$servo_name:camel Controller>] {
-                #[doc = concat!("Sync read raw register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!(<$conv as Conversion>::UsiType), ")")]
+                #[doc = concat!("Sync read raw register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", converted by ", stringify!($conv), ")")]
                 pub fn [<sync_read_raw_ $reg_name>](
                     &mut self,
                     ids: &[u8],
@@ -510,7 +514,7 @@ macro_rules! generate_reg_read {
                     )
                 }
 
-                #[doc = concat!("Sync read register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Sync read register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<sync_read_ $reg_name>](
                     &mut self,
                     ids: &[u8],
@@ -522,7 +526,7 @@ macro_rules! generate_reg_read {
                     )
                 }
 
-                #[doc = concat!("Read raw register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!(<$conv as Conversion>::UsiType), ")")]
+                #[doc = concat!("Read raw register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", converted by ", stringify!($conv), ")")]
                 pub fn [<read_raw_ $reg_name>](
                     &mut self,
                     id: u8,
@@ -539,7 +543,7 @@ macro_rules! generate_reg_read {
                     r
                 }
 
-                #[doc = concat!("Read register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Read register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<read_ $reg_name>](
                     &mut self,
                     id: u8,
@@ -562,7 +566,7 @@ macro_rules! generate_reg_read {
             #[gen_stub_pymethods]
             #[pymethods]
             impl [<$servo_name:camel PyController>] {
-                #[doc = concat!("Sync read raw register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Sync read raw register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<sync_read_raw_ $reg_name>](
                     &self,
                     py: Python,
@@ -576,7 +580,7 @@ macro_rules! generate_reg_read {
                     Ok(l.into())
                 }
 
-                #[doc = concat!("Sync read register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Sync read register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<sync_read_ $reg_name>](
                     &self,
                     py: Python,
@@ -590,7 +594,7 @@ macro_rules! generate_reg_read {
                     Ok(l.into())
                 }
 
-                #[doc = concat!("Read raw register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Read raw register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<read_raw_ $reg_name>](
                     &self,
                     py: Python,
@@ -604,7 +608,7 @@ macro_rules! generate_reg_read {
                     Ok(l.into())
                 }
 
-                #[doc = concat!("Read register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Read register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<read_ $reg_name>](
                     &self,
                     py: Python,
@@ -627,7 +631,7 @@ macro_rules! generate_reg_read {
 macro_rules! generate_reg_write {
     ($servo_name:ident, $reg_name:ident, $reg_addr:expr, $reg_type:ty, None) => {
         paste::paste! {
-            #[doc = concat!("Write register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+            #[doc = concat!("Write register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
             pub fn [<write_ $reg_name>](
                 io: &$crate::DynamixelProtocolHandler,
                 serial_port: &mut dyn serialport::SerialPort,
@@ -637,7 +641,7 @@ macro_rules! generate_reg_write {
                 io.write(serial_port, id, $reg_addr, &val.to_le_bytes())
             }
 
-            #[doc = concat!("Sync write register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+            #[doc = concat!("Sync write register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
             pub fn [<sync_write_ $reg_name>](
                 io: &$crate::DynamixelProtocolHandler,
                 serial_port: &mut dyn serialport::SerialPort,
@@ -656,7 +660,7 @@ macro_rules! generate_reg_write {
             }
 
             impl [<$servo_name:camel Controller>] {
-                #[doc = concat!("Sync write register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Sync write register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<sync_write_ $reg_name>](
                     &mut self,
                     ids: &[u8],
@@ -671,7 +675,7 @@ macro_rules! generate_reg_write {
                 }
 
 
-                #[doc = concat!("Write register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Write register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<write_ $reg_name>](
                     &mut self,
                     id: u8,
@@ -691,7 +695,7 @@ macro_rules! generate_reg_write {
             #[gen_stub_pymethods]
             #[pymethods]
             impl [<$servo_name:camel PyController>] {
-                #[doc = concat!("Sync write register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Sync write register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<sync_write_ $reg_name>](
                     &self,
                     ids: Bound<'_, pyo3::types::PyList>,
@@ -705,7 +709,7 @@ macro_rules! generate_reg_write {
                     })
                 }
 
-                #[doc = concat!("Write register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Write register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<write_ $reg_name>](
                     &self,
                     id: u8,
@@ -724,7 +728,7 @@ macro_rules! generate_reg_write {
     };
     ($servo_name:ident, $reg_name:ident, $reg_addr:expr, $reg_type:ty, $conv:ident) => {
         paste::paste! {
-            #[doc = concat!("Write register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+            #[doc = concat!("Write raw register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
             pub fn [<write_raw_ $reg_name>](
                 io: &$crate::DynamixelProtocolHandler,
                 serial_port: &mut dyn serialport::SerialPort,
@@ -734,6 +738,7 @@ macro_rules! generate_reg_write {
                 io.write(serial_port, id, $reg_addr, &val.to_le_bytes())
             }
 
+            #[doc = concat!("Write register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", converted by ", stringify!($conv), ")")]
             pub fn [<write_ $reg_name>](
                 io: &$crate::DynamixelProtocolHandler,
                 serial_port: &mut dyn serialport::SerialPort,
@@ -744,7 +749,7 @@ macro_rules! generate_reg_write {
                 [<write_raw_ $reg_name>](io, serial_port, id, val)
             }
 
-            #[doc = concat!("Sync write register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+            #[doc = concat!("Sync write raw register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
             pub fn [<sync_write_raw_ $reg_name>](
                 io: &$crate::DynamixelProtocolHandler,
                 serial_port: &mut dyn serialport::SerialPort,
@@ -762,6 +767,7 @@ macro_rules! generate_reg_write {
                 )
             }
 
+            #[doc = concat!("Sync write register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", converted by ", stringify!($conv), ")")]
             pub fn [<sync_write_ $reg_name>](
                 io: &$crate::DynamixelProtocolHandler,
                 serial_port: &mut dyn serialport::SerialPort,
@@ -776,7 +782,7 @@ macro_rules! generate_reg_write {
             }
 
             impl [<$servo_name:camel Controller>] {
-                #[doc = concat!("Sync write raw register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Sync write raw register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<sync_write_raw_ $reg_name>](
                     &mut self,
                     ids: &[u8],
@@ -790,7 +796,7 @@ macro_rules! generate_reg_write {
                     )
                 }
 
-                #[doc = concat!("Sync write register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!(<$conv as Conversion>::UsiType), ")")]
+                #[doc = concat!("Sync write register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", converted by ", stringify!($conv), ")")]
                 pub fn [<sync_write_ $reg_name>](
                     &mut self,
                     ids: &[u8],
@@ -804,7 +810,7 @@ macro_rules! generate_reg_write {
                     )
                 }
 
-                #[doc = concat!("Write raw register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Write raw register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<write_raw_ $reg_name>](
                     &mut self,
                     id: u8,
@@ -818,7 +824,7 @@ macro_rules! generate_reg_write {
                     )
                 }
 
-                #[doc = concat!("Write register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!(<$conv as Conversion>::UsiType), ")")]
+                #[doc = concat!("Write register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", converted by ", stringify!($conv), ")")]
                 pub fn [<write_ $reg_name>](
                     &mut self,
                     id: u8,
@@ -838,7 +844,7 @@ macro_rules! generate_reg_write {
             #[gen_stub_pymethods]
             #[pymethods]
             impl [<$servo_name:camel PyController>] {
-                #[doc = concat!("Sync write raw register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Sync write raw register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<sync_write_raw_ $reg_name>](
                     &self,
                     ids: Bound<'_, pyo3::types::PyList>,
@@ -852,7 +858,7 @@ macro_rules! generate_reg_write {
                     })
                 }
 
-                #[doc = concat!("Sync write register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Sync write register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<sync_write_ $reg_name>](
                     &self,
                     ids: &Bound<'_, pyo3::types::PyList>,
@@ -867,7 +873,7 @@ macro_rules! generate_reg_write {
                 }
 
 
-                #[doc = concat!("Write raw register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Write raw register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<write_raw_ $reg_name>](
                     &self,
                     id: u8,
@@ -879,7 +885,7 @@ macro_rules! generate_reg_write {
                     })
                 }
 
-                #[doc = concat!("Write register *", stringify!($name), "* (addr: ", stringify!($addr), ", type: ", stringify!($reg_type), ")")]
+                #[doc = concat!("Write register *", stringify!($reg_name), "* (addr: ", stringify!($reg_addr), ", type: ", stringify!($reg_type), ")")]
                 pub fn [<write_ $reg_name>](
                     &self,
                     id: u8,

--- a/src/servo/servo_macro.rs
+++ b/src/servo/servo_macro.rs
@@ -40,6 +40,23 @@ macro_rules! generate_servo {
         #[cfg(feature = "python")]
         use pyo3_stub_gen::derive::*;
 
+        /// Every register of this servo, in declaration order.
+        ///
+        /// Useful when the registers are chosen at runtime rather than in source, e.g.
+        /// building an indirect address map or a tool that takes register names.
+        pub const REGISTERS: &[$crate::servo::RegisterInfo] = &[
+            $($crate::servo::RegisterInfo {
+                name: stringify!($reg_name),
+                addr: $reg_addr,
+                size: std::mem::size_of::<$reg_type>() as u8,
+            },)*
+        ];
+
+        /// Look up a register by name, as spelled in [`REGISTERS`].
+        pub fn register(name: &str) -> Option<$crate::servo::RegisterInfo> {
+            REGISTERS.iter().copied().find(|r| r.name == name)
+        }
+
         $crate::generate_protocol_constructor!($servo_name, $protocol);
         $crate::generate_special_instructions!($servo_name);
         $crate::generate_addr_read_write!($servo_name);


### PR DESCRIPTION
Adds an example for Dynamixel indirect addressing, which allows non-contiguous control table elements to be recorded without reading unwanted intermediate bytes. A strict speed-up for non-contiguous sync reads, but requires a startup sync write.

Also includes the exposition of control table elements by string, and docs fixes found along the way.

## TLDR

- exposes servo control tables as `REGISTERS` to let callers work with a register chosen at runtime instead of hardcoding addresses or hand-maintaining a name-to-function match
- presents an example to efficiently use indirect addressing on Dynamixel XL330, aided by the exposition of servo control tables
  - note: indirect addresses live in RAM and must be reconfigured on each startup (implemented as a single sync write command in the example)
- includes documentation fixes related to registers discovered while implementing the main feature and example

## Commits

1. fixes register `#[doc]` attributes (found incidentally while doing 2)
2. exposes servo control table registers
3. indirect addressing example, simplified by 2

Nothing changes for existing callers: commit 1 touches only `#[doc]` attributes, commits 2 and 3 are additive. Each builds and tests on its own, so 1 can be taken alone if the API in 2 needs discussion.

## 1. Fix and complete the generated register documentation

Three issues, all in the doc attributes that `generate_reg_read!` and `generate_reg_write!` attach to the accessors they emit. This applies to all servo types, e.g. not only Dynamixel XL330.

**1.1. Unexpanded placeholders.** Both macros take `$reg_name` and `$reg_addr`, but their doc attributes referenced `$name` and `$addr`. Neither is bound, so `stringify!` captured the tokens literally and every accessor documents itself as:

```
Read register $name (addr: $addr, type: u16)
```

Visible today at [`fn.read_realtime_tick`](https://docs.rs/rustypot/1.7.0/rustypot/servo/dynamixel/xl330/fn.read_realtime_tick.html), and on the equivalent function for every register on every servo.

`generate_reg_write_fb!` is deliberately untouched (declares its parameters as `$name` and `$addr`, so its doc attributes were already correct).

**1.2. Converted accessors had no docs at all.** `read_present_position` and its siblings were undocumented; only `read_raw_present_position` carried one. The placeholder above was only visible on a register with no conversion.

**1.3. Raw and converted accessors were reading identically.** Both said "Read register", so the raw ones are relabelled and the converted ones name their conversion:

```
Read register present_position (addr: 132, converted by AnglePosition)
Read raw register present_position (addr: 132, type: i32)
```

The converted type was previously stringified as `<$conv as Conversion>::UsiType` in the few places it appeared, which rendered as the ugly `< AnglePosition as Conversion > :: UsiType`.

## 2. Expose each servo's control table as `REGISTERS`

`generate_servo!` already knows every register's name, address and size, but emitted only accessor functions — so nothing can work with a register chosen at runtime. Downstream code ends up hand-maintaining a name-to-function match; `duck-control` in `pollen-robotics/microduck` has:

```rust
let raw = match name {
    "return_delay_time" => self.controller.read_return_delay_time(id),
    "baud_rate" => self.controller.read_baud_rate(id),
    ...
    other => unreachable!("unhandled register {other}"),
};
```

which has to be extended by hand for every register it wants to touch.

Each servo module now also gets:

```rust
pub const REGISTERS: &[RegisterInfo]
pub fn register(name: &str) -> Option<RegisterInfo>
```

`RegisterInfo` carries name, address and size. All servos get it from the same macro, so it cannot drift from the register definitions.

Note that `register()` uses a linear search but is trivial over ~69 entries (e.g. for XL330's registry). A `match` implementation ends up around the same performance.

**OPEN QUESTION,** since this is new public surface:

**Should `RegisterInfo` carry more than name, address and size?** `generate_servo!` also captures the access mode (`r` / `w` / `rw`) and the conversion for each register, so either could be included at no runtime cost:

```rust
pub struct RegisterInfo {
    pub name: &'static str,
    pub addr: u8,
    pub size: u8,
    // pub access: Access,        // r / w / rw
    // pub conversion: Option<&'static str>,
}
```

I left both out to keep the first version minimal. They are easy to add later and awkward to remove. `Access` would, for example, let a config tool refuse to write a read-only register instead of finding out from the servo.

Note that **`size` comes from `size_of::<$reg_type>()`**, which is the same assumption the macro already makes when computing read lengths. It equals the wire size only because this crate keeps Rust and wire types in step. This PR does not introduce that assumption, it just exposes it.

## 3. Indirect addressing example

Indirect addressing points a block of pointer slots at scattered registers so they can be read as one contiguous block. `examples/indirect_addressing.rs` maps a 'fast' block and a 'slow' block into one region, ordered so the same read covers either the fast registers alone or both — and compares three ways of getting the same data.

Registers are named on the command line and resolved through `REGISTERS`, which is what commit 2 was for:

```sh
cargo run --release --example indirect_addressing -- \
    --serialport /dev/ttyUSB0 --ids 1,2,3,4,5,6,7 \
    --fast realtime_tick,present_position --slow present_input_voltage
```

Measured on 7x XL330 (fw v53) at 1 Mbps, with the USB latency timer at 2 ms:

| | mean | wire bytes | transactions |
|---|---|---|---|
| one read per register | 6.00 ms | 350 | 3 |
| one wide read (26 B) | 4.00 ms | 280 | 1 |
| indirect (8 B) | 2.00 ms | 113 | 1 |

The wide read degrades as registers get more scattered: with `led` (65) and `present_temperature` (146) at the ends it spans 82 bytes and takes 8.00 ms (slower than three separate reads) while the indirect read stays at 2.00 ms because it only carries the desired bytes.

Configuring the map is also done with sync write. Indirect Address 1..N is contiguous, so one sync write sets up every motor at once: in this example, **113.9 ms over 56 transactions becomes 4.0 ms in one.** (well, two for safety here: 4ms instead of 2ms only because we are also confirming that the indirect map landed)

## Limitations

The example takes its base addresses from rustypot's own XL330 definition, which uses the firmware v53+ layout (indirect data at 224). On earlier firmware, where it lives at 208, the addresses would be wrong — the example's correctness check catches it (realistically, just update firmware).

## Compatibility

Purely additive. No signature changes, no behaviour changes; commit 1 alters only `#[doc]` attributes. `RegisterInfo` is a new public type in `servo`; `REGISTERS` and `register()` are new per-servo items.

## Testing

- `cargo build`, `cargo test` (39 unit + 11 doc tests), `cargo clippy --all-targets`,
  `cargo fmt --all -- --check` — all clean, and verified on each of the three commits
  independently
- `--features python` builds, and `stub_gen` runs and emits stubs
- `cargo doc` output checked by hand for every affected accessor shape: plain, raw, and
  converted
- Example run against 7x XL330 on a U2D2: all three read strategies return identical
  data, and the indirect map is verified by reading the table back
